### PR TITLE
Update scheduler imports and misc apis to make filter.exe compile

### DIFF
--- a/parallel-example/dune
+++ b/parallel-example/dune
@@ -1,6 +1,6 @@
 (library
  (name parallel_example)
  (public_name parallel_example)
- (libraries base parallel parallel_scheduler_work_stealing portable stdio)
+ (libraries base parallel parallel.scheduler portable stdio)
  (preprocess
   (pps ppx_jane)))

--- a/parallel-example/filter/dune
+++ b/parallel-example/filter/dune
@@ -2,7 +2,6 @@
  (modes byte exe)
  (names filter)
  (libraries core_unix.command_unix core parallel
-   parallel.scheduler.work_stealing portable core_unix.time_stamp_counter)
+   parallel.scheduler portable core_unix.time_stamp_counter)
  (preprocess
   (pps ppx_jane)))
-

--- a/parallel-example/filter/filter.ml
+++ b/parallel-example/filter/filter.ml
@@ -17,12 +17,11 @@ let blur_at image ~x ~y =
 ;;
 
 let filter ~scheduler ~key image =
-  let monitor = Parallel.Monitor.create_root () in
-  Parallel_scheduler_work_stealing.schedule scheduler ~monitor ~f:(fun parallel ->
+  Parallel_scheduler.parallel scheduler ~f:(fun parallel ->
     let width = Image.width (Capsule.Data.project image) in
     let height = Image.height (Capsule.Data.project image) in
     let data =
-      Parallel_array.init parallel (width * height) ~f:(fun i ->
+      Parallel_array.init parallel (width * height) ~f:(fun _ i ->
         let x = i % width in
         let y = i / width in
         (Capsule.Key.access_shared key ~f:(fun access ->
@@ -37,10 +36,10 @@ let command =
     ~summary:"filter an image"
     [%map_open.Command
       let file = anon (maybe_with_default "ox.pgm" ("FILE" %: string))
-      and domains = flag "domains" (optional int) ~doc:"INT number of domains" in
+      and max_domains = flag "domains" (optional int) ~doc:"INT number of domains" in
       fun () ->
         let scheduler =
-          (Parallel_scheduler_work_stealing.create [@alert "-experimental"]) ?domains ()
+          (Parallel_scheduler.create [@alert "-experimental"]) ?max_domains ()
         in
         let (P key) = Capsule.create () in
         let image = Capsule.Data.create (fun () -> Image.load file) in

--- a/parallel-example/sort.ml
+++ b/parallel-example/sort.ml
@@ -69,9 +69,9 @@ module Parallel = struct
   ;;
 
   let%bench_fun "parallel" =
-    let domains = Sys.getenv "DOMAINS" |> Option.bind ~f:Int.of_string_opt in
+    let max_domains = Sys.getenv "DOMAINS" |> Option.bind ~f:Int.of_string_opt in
     let scheduler =
-      (Parallel_scheduler.create [@alert "-experimental"]) ?domains ()
+      (Parallel_scheduler.create [@alert "-experimental"]) ?max_domains ()
     in
     let (P key) = Capsule.create () in
     let mutex = Mutex.create key in

--- a/parallel-example/sort.ml
+++ b/parallel-example/sort.ml
@@ -47,7 +47,7 @@ module Parallel = struct
     if Slice.length slice > 1
     then (
       let pivot = partition slice in
-      let (), () =
+      let #((), ()) =
         Slice.fork_join2
           parallel
           ~pivot
@@ -59,10 +59,9 @@ module Parallel = struct
   ;;
 
   let quicksort ~scheduler ~mutex array =
-    let monitor = Parallel.Monitor.create_root () in
-    Parallel_scheduler_work_stealing.schedule scheduler ~monitor ~f:(fun parallel ->
-      Capsule.Mutex.with_lock mutex ~f:(fun password ->
-        Capsule.Data.iter array ~password ~f:(fun array ->
+    Parallel_scheduler.parallel scheduler ~f:(fun parallel ->
+      Mutex.with_lock mutex ~f:(fun password ->
+        Data.iter array ~password ~f:(fun array ->
           let array = Par_array.of_array array in
           quicksort parallel (Slice.slice array) [@nontail])
         [@nontail])
@@ -72,12 +71,12 @@ module Parallel = struct
   let%bench_fun "parallel" =
     let domains = Sys.getenv "DOMAINS" |> Option.bind ~f:Int.of_string_opt in
     let scheduler =
-      (Parallel_scheduler_work_stealing.create [@alert "-experimental"]) ?domains ()
+      (Parallel_scheduler.create [@alert "-experimental"]) ?domains ()
     in
     let (P key) = Capsule.create () in
-    let mutex = Capsule.Mutex.create key in
+    let mutex = Mutex.create key in
     let array =
-      Capsule.Data.create (fun () -> Array.init 10_000 ~f:(fun _ -> Random.int 10_000))
+      Data.create (fun () -> Array.init 10_000 ~f:(fun _ -> Random.int 10_000))
     in
     fun () -> quicksort ~scheduler ~mutex array
   ;;


### PR DESCRIPTION
Currently the example doesn't compile. This PR updates some APIs I was able to figure out how to update.

Note that `Capsule.Mutex` is still unbound, so `sort.ml` and `capsules.ml` still do not compile.

<img width="901" height="556" alt="Screenshot 2026-01-03 at 17 43 54" src="https://github.com/user-attachments/assets/bf7c2f9f-2a62-4f66-97a2-6705ec657b7f" />
